### PR TITLE
fix: Automated fix for #25: 'Reveal in Finder' not working

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -4,6 +4,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { assertDestRefreshAfterConvert } from "../../tests/refresh-dest.mjs";
 import { assertRevealInFinder } from "../../tests/reveal-in-finder.mjs";
+import { assertRevealInFinderDest } from "../../tests/reveal-in-finder-dest.mjs";
 import { assertRevealFileInFinder } from "../../tests/reveal-file-in-finder.mjs";
 
 const baseUrl = process.env.E2E_BASE_URL ?? "http://localhost:3000";
@@ -230,6 +231,10 @@ try {
   await page.getByTestId("favorite-open-source-_Alpha").waitFor({ state: "visible" });
   await page.getByTestId("favorite-open-dest-_Beta").waitFor({ state: "visible" });
   await assertRevealInFinder(page);
+  await page.evaluate(() => {
+    window.__revealCalls = [];
+  });
+  await assertRevealInFinderDest(page);
   await page.evaluate(() => {
     window.__revealCalls = [];
   });

--- a/src/components/FilePane.tsx
+++ b/src/components/FilePane.tsx
@@ -2489,8 +2489,8 @@ export const FilePane = ({
       const isParentLink = node.id === "parent-link";
       const isSelected = selectedItems.has(node.id);
 
-      const handleRevealInFinder = async (e: React.MouseEvent) => {
-        e.stopPropagation();
+      const handleRevealInFinder = async (e?: Event) => {
+        e?.stopPropagation();
         if (isParentLink) return;
 
         try {
@@ -2662,7 +2662,7 @@ export const FilePane = ({
             </ContextMenuTrigger>
             {!isParentLink && (
               <ContextMenuContent>
-                <ContextMenuItem onClick={handleRevealInFinder}>Reveal in Finder</ContextMenuItem>
+                <ContextMenuItem onSelect={handleRevealInFinder}>Reveal in Finder</ContextMenuItem>
                 {node.type === "folder" && (
                   <ContextMenuItem
                     onClick={(e) => {

--- a/tests/reveal-in-finder-dest.mjs
+++ b/tests/reveal-in-finder-dest.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+
+export async function assertRevealInFinderDest(page) {
+  const betaNode = page.getByTestId("tree-node-dest-_Beta");
+  await betaNode.waitFor({ state: "visible" });
+  await betaNode.click({ button: "right" });
+
+  const revealMenuItem = page.getByRole("menuitem", { name: "Reveal in Finder" });
+  await revealMenuItem.waitFor({ state: "visible" });
+  await revealMenuItem.click();
+
+  await page.waitForFunction(() => Array.isArray(window.__revealCalls) && window.__revealCalls.length >= 1);
+  const revealCalls = await page.evaluate(() => window.__revealCalls);
+  const lastCall = revealCalls.at(-1);
+  assert.ok(lastCall, "Expected a reveal call for the destination folder.");
+  assert.equal(lastCall.virtualPath, "/Beta", "Reveal should use the destination folder path.");
+  assert.equal(lastCall.paneType, "dest", "Reveal should use the destination pane type.");
+  assert.equal(lastCall.isDirectory, true, "Reveal should indicate the folder is a directory.");
+}


### PR DESCRIPTION
Automated fix for issue #25: 'Reveal in Finder' not working. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed