### PR TITLE
fix: Automated fix for #31: Long sample names extend past the end of the convert status dialog

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -6,6 +6,7 @@ import { assertDestRefreshAfterConvert } from "../../tests/refresh-dest.mjs";
 import { assertRevealInFinder } from "../../tests/reveal-in-finder.mjs";
 import { assertRevealInFinderDest } from "../../tests/reveal-in-finder-dest.mjs";
 import { assertRevealFileInFinder } from "../../tests/reveal-file-in-finder.mjs";
+import { assertConvertDialogEllipsis } from "../../tests/convert-dialog-ellipsis.mjs";
 
 const baseUrl = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 const headless = process.env.PW_HEADLESS !== "false";
@@ -104,9 +105,14 @@ try {
     const root = new MockDirectoryHandle("Root");
     const alpha = root.addDirectory(new MockDirectoryHandle("Alpha"));
     const beta = root.addDirectory(new MockDirectoryHandle("Beta"));
+    const longNames = root.addDirectory(new MockDirectoryHandle("LongNames"));
     alpha.addFile("inside-alpha.wav", 128);
     beta.addFile("inside-beta.wav", 128);
     root.addFile("top-level.txt", 32);
+    longNames.addFile(
+      "this-is-an-extremely-long-sample-name-designed-to-overflow-the-dialog-display.wav",
+      128,
+    );
 
     const ensureDirectoryByPath = (virtualPath) => {
       const parts = virtualPath.split("/").filter(Boolean);
@@ -155,11 +161,28 @@ try {
             ],
           };
         }
+        if (startPath === "/LongNames") {
+          return {
+            success: true,
+            data: [
+              {
+                name: "this-is-an-extremely-long-sample-name-designed-to-overflow-the-dialog-display.wav",
+                path: "/LongNames/this-is-an-extremely-long-sample-name-designed-to-overflow-the-dialog-display.wav",
+                type: "file",
+                size: 128,
+                isDirectory: false,
+              },
+            ],
+          };
+        }
         return { success: true, data: [] };
       },
-      convertAndCopyFile: (args) => {
+      convertAndCopyFile: async (args) => {
         window.__convertCalls.push(args);
         addFileToPath(args.destVirtualPath, args.fileName);
+        if (args.fileName.length > 40) {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
         return { success: true };
       },
       revealInFinder: ({ virtualPath, paneType, isDirectory }) => {
@@ -346,6 +369,10 @@ try {
 
   await page.getByTestId("tree-node-source-_Alpha").click();
   await destBetaNode.click();
+
+  await assertConvertDialogEllipsis(page);
+
+  await page.getByTestId("tree-node-source-_Alpha").click();
 
   await formatButton.click();
   await page.getByRole("menuitem", { name: "Sample Rate" }).hover();

--- a/src/components/MiddleEllipsis.tsx
+++ b/src/components/MiddleEllipsis.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type MiddleEllipsisProps = React.HTMLAttributes<HTMLSpanElement> & {
+  value: string;
+};
+
+const DEFAULT_TAIL_LENGTH = 12;
+
+function splitForMiddleEllipsis(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { start: "", end: "" };
+  }
+
+  const dotIndex = trimmed.lastIndexOf(".");
+  if (dotIndex > 0 && dotIndex < trimmed.length - 1) {
+    return {
+      start: trimmed.slice(0, dotIndex),
+      end: trimmed.slice(dotIndex),
+    };
+  }
+
+  if (trimmed.length <= DEFAULT_TAIL_LENGTH) {
+    return { start: trimmed, end: "" };
+  }
+
+  return {
+    start: trimmed.slice(0, -DEFAULT_TAIL_LENGTH),
+    end: trimmed.slice(-DEFAULT_TAIL_LENGTH),
+  };
+}
+
+const MiddleEllipsis = ({ value, className, ...props }: MiddleEllipsisProps) => {
+  const { start, end } = React.useMemo(() => splitForMiddleEllipsis(value), [value]);
+
+  if (!start && !end) {
+    return null;
+  }
+
+  return (
+    <span className={cn("flex min-w-0 items-baseline", className)} title={value} {...props}>
+      <span className="min-w-0 truncate">{start}</span>
+      {end ? <span className="shrink-0">{end}</span> : null}
+    </span>
+  );
+};
+
+export default MiddleEllipsis;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import MiddleEllipsis from "@/components/MiddleEllipsis";
 import { Progress } from "@/components/ui/progress";
 import { Play, FolderPlus } from "lucide-react";
 import { fileSystemService } from "@/lib/fileSystem";
@@ -498,10 +499,18 @@ const Index = () => {
       {conversionProgress?.isVisible && (
         <Dialog open={true} onOpenChange={() => {}}>
           <DialogContent className="sm:max-w-md">
-            <DialogHeader>
+            <DialogHeader className="min-w-0">
               <DialogTitle>Converting Files</DialogTitle>
-              <DialogDescription className="mt-2 truncate">
-                {conversionProgress.currentFile ?? "Preparing conversion..."}
+              <DialogDescription className="mt-2 min-w-0">
+                {conversionProgress.currentFile ? (
+                  <MiddleEllipsis
+                    className="w-full min-w-0 text-left"
+                    data-testid="conversion-current-file"
+                    value={conversionProgress.currentFile}
+                  />
+                ) : (
+                  "Preparing conversion..."
+                )}
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4 py-4">

--- a/tests/convert-dialog-ellipsis.mjs
+++ b/tests/convert-dialog-ellipsis.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+
+export async function assertConvertDialogEllipsis(page) {
+  const sourceLongNames = page.getByTestId("tree-node-source-_LongNames");
+  await sourceLongNames.waitFor({ state: "visible" });
+  await sourceLongNames.click();
+
+  const convertButton = page.getByRole("button", { name: "Convert" });
+  await convertButton.click();
+
+  const confirmButtons = ["Convert & Save", "Copy"];
+  let confirmClicked = false;
+  for (const name of confirmButtons) {
+    const button = page.getByRole("button", { name });
+    if (await button.isVisible().catch(() => false)) {
+      await button.click();
+      confirmClicked = true;
+      break;
+    }
+  }
+  assert.ok(confirmClicked, "Expected to confirm conversion or copy.");
+
+  const dialog = page.getByRole("dialog");
+  await dialog.waitFor({ state: "visible" });
+
+  const fileLabel = page.getByTestId("conversion-current-file");
+  await fileLabel.waitFor({ state: "visible" });
+
+  const dialogBox = await dialog.boundingBox();
+  const labelBox = await fileLabel.boundingBox();
+
+  assert.ok(dialogBox, "Expected conversion dialog to have a bounding box.");
+  assert.ok(labelBox, "Expected conversion file label to have a bounding box.");
+  assert.ok(
+    labelBox.x + labelBox.width <= dialogBox.x + dialogBox.width,
+    `Expected file label to fit inside dialog. labelRight=${labelBox.x + labelBox.width}, dialogRight=${
+      dialogBox.x + dialogBox.width
+    }`,
+  );
+
+  const endSegment = await fileLabel.locator("span").last().textContent();
+  assert.ok(
+    endSegment?.endsWith(".wav"),
+    `Expected ellipsis to preserve file extension. segment=${endSegment}`,
+  );
+
+  await fileLabel.waitFor({ state: "hidden" });
+
+  await page.evaluate(() => {
+    window.__listCalls = [];
+    window.__convertCalls = [];
+  });
+}


### PR DESCRIPTION
Automated fix for issue #31: Long sample names extend past the end of the convert status dialog. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed