### PR TITLE
fix: Automated fix for #34: We should remember the state of the folders on relaunch

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -7,6 +7,7 @@ import { assertRevealInFinder } from "../../tests/reveal-in-finder.mjs";
 import { assertRevealInFinderDest } from "../../tests/reveal-in-finder-dest.mjs";
 import { assertRevealFileInFinder } from "../../tests/reveal-file-in-finder.mjs";
 import { assertConvertDialogEllipsis } from "../../tests/convert-dialog-ellipsis.mjs";
+import { assertExpandedFoldersPersistOnReload } from "../../tests/persist-expanded-folders.mjs";
 
 const baseUrl = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 const headless = process.env.PW_HEADLESS !== "false";
@@ -250,6 +251,8 @@ try {
   });
 
   const sourceAlphaNode = page.getByTestId("tree-node-source-_Alpha");
+  await sourceAlphaNode.waitFor({ state: "visible" });
+  await assertExpandedFoldersPersistOnReload(page);
   await sourceAlphaNode.waitFor({ state: "visible" });
   await page.getByTestId("favorite-open-source-_Alpha").waitFor({ state: "visible" });
   await page.getByTestId("favorite-open-dest-_Beta").waitFor({ state: "visible" });

--- a/src/components/FilePane.tsx
+++ b/src/components/FilePane.tsx
@@ -44,6 +44,7 @@ import { fileSystemService } from "@/lib/fileSystem";
 
 // Registry to track active pane and clear selections in other panes
 const paneRegistry = new Map<string, () => void>();
+const NAV_STATE_FALLBACK_VOLUME = "_default";
 
 // Simple path join utility for cross-platform compatibility
 function joinPath(...parts: string[]): string {
@@ -218,6 +219,7 @@ export const FilePane = ({
   const searchCancelledRef = useRef<boolean>(false);
   const isSearchingRef = useRef<boolean>(false);
   const currentSearchQueryRef = useRef<string>("");
+  const hasInitializedNavStateRef = useRef<boolean>(false);
   const paneContainerRef = useRef<HTMLDivElement>(null);
   const handleDeleteRef = useRef<((node?: FileNode) => Promise<void>) | null>(null);
   const { saveNavigationState, getNavigationState } = useNavigationState(paneName);
@@ -699,7 +701,7 @@ export const FilePane = ({
       cancelled = true;
       timeouts.forEach((timeout) => clearTimeout(timeout));
     };
-  }, [pendingExpandedFolders, loadDirectory, isRestoringExpanded, isSearchingFolders]); // Added isSearchingFolders to prevent running during search
+  }, [pendingExpandedFolders, fileTree, loadDirectory, isRestoringExpanded, isSearchingFolders]); // Include fileTree so restoration can run once async directory load completes
 
   // Restore selected items after expanded folders are restored
   useEffect(() => {
@@ -746,6 +748,7 @@ export const FilePane = ({
   useEffect(() => {
     let cancelled = false;
     const timeouts: NodeJS.Timeout[] = [];
+    hasInitializedNavStateRef.current = false;
 
     console.log("useEffect: autoNavigateToCard, paneName:", paneName);
 
@@ -910,29 +913,28 @@ export const FilePane = ({
 
           // Try to restore saved navigation state for home volume
           initialPath = homePath;
-          if (volumeUUID) {
-            const savedState = getNavigationState(volumeUUID);
-            if (savedState) {
-              // Verify the saved path still exists and is accessible
-              try {
-                const statsResult = await fileSystemService.getFileStats(savedState.currentPath, paneType);
-                if (statsResult.success && statsResult.data?.isDirectory) {
-                  initialPath = savedState.currentPath;
-                  console.log(
-                    `${paneName} - Restored navigation state for home volume UUID:`,
-                    volumeUUID,
-                    "to:",
-                    savedState.currentPath,
-                  );
-                } else {
-                  console.log(`${paneName} - Saved path exists but is not a directory, using home directory`);
-                }
-              } catch {
-                console.log(`${paneName} - Saved path no longer exists, using home directory`);
+          const navStateVolumeUUID = volumeUUID ?? NAV_STATE_FALLBACK_VOLUME;
+          const savedState = getNavigationState(navStateVolumeUUID);
+          if (savedState) {
+            // Verify the saved path still exists and is accessible
+            try {
+              const statsResult = await fileSystemService.getFileStats(savedState.currentPath, paneType);
+              if (statsResult.success && statsResult.data?.isDirectory) {
+                initialPath = savedState.currentPath;
+                console.log(
+                  `${paneName} - Restored navigation state for home volume UUID:`,
+                  navStateVolumeUUID,
+                  "to:",
+                  savedState.currentPath,
+                );
+              } else {
+                console.log(`${paneName} - Saved path exists but is not a directory, using home directory`);
               }
-            } else {
-              console.log(`${paneName} - No saved navigation state found for home volume UUID:`, volumeUUID);
+            } catch {
+              console.log(`${paneName} - Saved path no longer exists, using home directory`);
             }
+          } else {
+            console.log(`${paneName} - No saved navigation state found for home volume UUID:`, navStateVolumeUUID);
           }
 
           setCurrentRootPath(initialPath);
@@ -942,11 +944,8 @@ export const FilePane = ({
           await loadDirectory(initialPath, "root");
 
           // Restore expanded folders after loading
-          if (volumeUUID) {
-            const savedState = getNavigationState(volumeUUID);
-            if (savedState?.expandedFolders && savedState.expandedFolders.length > 0) {
-              setPendingExpandedFolders(savedState.expandedFolders);
-            }
+          if (savedState?.expandedFolders && savedState.expandedFolders.length > 0) {
+            setPendingExpandedFolders(savedState.expandedFolders);
           }
         } else {
           console.error(`${paneName} - Failed to get home directory`);
@@ -957,6 +956,7 @@ export const FilePane = ({
         }
       } finally {
         if (!cancelled) {
+          hasInitializedNavStateRef.current = true;
           setLoading(false);
         }
       }
@@ -1018,9 +1018,7 @@ export const FilePane = ({
     setExpandedFolders(newExpanded);
 
     // Save navigation state with expanded folders
-    if (currentVolumeUUID) {
-      saveNavigationState(currentVolumeUUID, currentRootPath, newExpanded);
-    }
+    saveNavigationState(currentVolumeUUID ?? NAV_STATE_FALLBACK_VOLUME, currentRootPath, newExpanded);
   };
 
   const navigateToFolder = useCallback(
@@ -1038,11 +1036,10 @@ export const FilePane = ({
 
       // Get volume UUID for the new path and save navigation state
       const volumeUUID = await getVolumeUUIDForPath(folderPath);
-      if (volumeUUID) {
-        setCurrentVolumeUUID(volumeUUID);
-        saveNavigationState(volumeUUID, folderPath, new Set());
-        console.log(`${paneName} - Saved navigation state for volume UUID:`, volumeUUID, "path:", folderPath);
-      }
+      const navStateVolumeUUID = volumeUUID ?? NAV_STATE_FALLBACK_VOLUME;
+      setCurrentVolumeUUID(volumeUUID);
+      saveNavigationState(navStateVolumeUUID, folderPath, new Set());
+      console.log(`${paneName} - Saved navigation state for volume UUID:`, navStateVolumeUUID, "path:", folderPath);
 
       await loadDirectory(folderPath, "root");
     },
@@ -1194,21 +1191,32 @@ export const FilePane = ({
   // Save navigation state whenever currentRootPath or expandedFolders changes
   useEffect(() => {
     const saveCurrentPath = async () => {
-      if (!currentRootPath || !currentVolumeUUID) return;
+      if (!currentRootPath) return;
+      if (!fileSystemService.hasRootForPane(paneType)) return;
+      if (!hasInitializedNavStateRef.current) return;
+      if (pendingExpandedFolders.length > 0 || isRestoringExpanded) return;
 
-      if (currentVolumeUUID) {
-        saveNavigationState(currentVolumeUUID, currentRootPath, expandedFolders);
-        console.log(
-          `${paneName} - Auto-saved navigation state for volume UUID:`,
-          currentVolumeUUID,
-          "path:",
-          currentRootPath,
-        );
-      }
+      const navStateVolumeUUID = currentVolumeUUID ?? NAV_STATE_FALLBACK_VOLUME;
+      saveNavigationState(navStateVolumeUUID, currentRootPath, expandedFolders);
+      console.log(
+        `${paneName} - Auto-saved navigation state for volume UUID:`,
+        navStateVolumeUUID,
+        "path:",
+        currentRootPath,
+      );
     };
 
     saveCurrentPath();
-  }, [currentRootPath, currentVolumeUUID, expandedFolders, saveNavigationState, paneName]);
+  }, [
+    currentRootPath,
+    currentVolumeUUID,
+    expandedFolders,
+    saveNavigationState,
+    paneName,
+    paneType,
+    pendingExpandedFolders,
+    isRestoringExpanded,
+  ]);
 
   // Notify parent of path/volume changes for external favorites columns
   useEffect(() => {
@@ -2294,25 +2302,24 @@ export const FilePane = ({
 
         // Try to restore saved navigation state
         let initialPath = homePath;
-        if (volumeUUID) {
-          const savedState = getNavigationState(volumeUUID);
-          if (savedState) {
-            try {
-              const statsResult = await fileSystemService.getFileStats(savedState.currentPath, paneType);
-              if (statsResult.success && statsResult.data?.isDirectory) {
-                initialPath = savedState.currentPath;
-                console.log(
-                  `${paneName} - Restored navigation state for home volume UUID:`,
-                  volumeUUID,
-                  "to:",
-                  savedState.currentPath,
-                );
-              } else {
-                console.log(`${paneName} - Saved path exists but is not a directory, using home directory`);
-              }
-            } catch {
-              console.log(`${paneName} - Saved path no longer exists, using home directory`);
+        const navStateVolumeUUID = volumeUUID ?? NAV_STATE_FALLBACK_VOLUME;
+        const savedState = getNavigationState(navStateVolumeUUID);
+        if (savedState) {
+          try {
+            const statsResult = await fileSystemService.getFileStats(savedState.currentPath, paneType);
+            if (statsResult.success && statsResult.data?.isDirectory) {
+              initialPath = savedState.currentPath;
+              console.log(
+                `${paneName} - Restored navigation state for home volume UUID:`,
+                navStateVolumeUUID,
+                "to:",
+                savedState.currentPath,
+              );
+            } else {
+              console.log(`${paneName} - Saved path exists but is not a directory, using home directory`);
             }
+          } catch {
+            console.log(`${paneName} - Saved path no longer exists, using home directory`);
           }
         }
 
@@ -2324,11 +2331,8 @@ export const FilePane = ({
         await loadDirectory(initialPath, "root");
 
         // Restore expanded folders after loading
-        if (volumeUUID) {
-          const savedState = getNavigationState(volumeUUID);
-          if (savedState?.expandedFolders && savedState.expandedFolders.length > 0) {
-            setPendingExpandedFolders(savedState.expandedFolders);
-          }
+        if (savedState?.expandedFolders && savedState.expandedFolders.length > 0) {
+          setPendingExpandedFolders(savedState.expandedFolders);
         }
         void refreshAvailableVolumes();
       }

--- a/src/hooks/use-navigation-state.ts
+++ b/src/hooks/use-navigation-state.ts
@@ -7,6 +7,12 @@ interface NavigationState {
   expandedFolders: string[];
 }
 
+const DEFAULT_VOLUME_KEY = "_default";
+
+function getStorageKey(paneName: string, volumeUUID?: string | null): string {
+  return `${STORAGE_KEY_PREFIX}${paneName}_${volumeUUID ?? DEFAULT_VOLUME_KEY}`;
+}
+
 /**
  * Hook for managing navigation state per pane per volume UUID
  */
@@ -15,10 +21,10 @@ export function useNavigationState(paneName: string) {
    * Save navigation state for a pane and volume UUID
    */
   const saveNavigationState = useCallback(
-    (volumeUUID: string, folderPath: string, expandedFolders: Set<string>) => {
+    (volumeUUID: string | null | undefined, folderPath: string, expandedFolders: Set<string>) => {
       try {
         console.log("Saving navigation state for pane:", paneName, "volume:", volumeUUID, "path:", folderPath);
-        const key = `${STORAGE_KEY_PREFIX}${paneName}_${volumeUUID}`;
+        const key = getStorageKey(paneName, volumeUUID);
         const state: NavigationState = {
           currentPath: folderPath,
           expandedFolders: Array.from(expandedFolders),
@@ -35,9 +41,9 @@ export function useNavigationState(paneName: string) {
    * Get saved navigation state for a pane and volume UUID
    */
   const getNavigationState = useCallback(
-    (volumeUUID: string): NavigationState | null => {
+    (volumeUUID: string | null | undefined): NavigationState | null => {
       try {
-        const key = `${STORAGE_KEY_PREFIX}${paneName}_${volumeUUID}`;
+        const key = getStorageKey(paneName, volumeUUID);
         const saved = localStorage.getItem(key);
         if (!saved) return null;
 
@@ -62,9 +68,9 @@ export function useNavigationState(paneName: string) {
    * Clear navigation state for a pane and volume UUID
    */
   const clearNavigationState = useCallback(
-    (volumeUUID: string) => {
+    (volumeUUID: string | null | undefined) => {
       try {
-        const key = `${STORAGE_KEY_PREFIX}${paneName}_${volumeUUID}`;
+        const key = getStorageKey(paneName, volumeUUID);
         localStorage.removeItem(key);
       } catch (error) {
         console.error("Failed to clear navigation state:", error);

--- a/tests/persist-expanded-folders.mjs
+++ b/tests/persist-expanded-folders.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+
+export async function assertExpandedFoldersPersistOnReload(page) {
+  const alphaNodeTestId = "tree-node-source-_Alpha";
+  const alphaChildTestId = "tree-node-source-_Alpha_inside-alpha_wav";
+
+  const alphaNode = page.getByTestId(alphaNodeTestId);
+  await alphaNode.waitFor({ state: "visible" });
+
+  await page.evaluate((testId) => {
+    const node = document.querySelector(`[data-testid="${testId}"]`);
+    if (!node) throw new Error("Source Alpha node not found");
+    if (node.getAttribute("data-expanded") !== "true") {
+      node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    }
+  }, alphaNodeTestId);
+
+  await page.getByTestId(alphaChildTestId).waitFor({ state: "visible" });
+  const persistedBeforeReload = await page.evaluate(() => localStorage.getItem("octacard_nav_state_source__default"));
+  assert.ok(persistedBeforeReload, "Expected navigation state to be persisted before reload.");
+
+  await page.reload({ waitUntil: "networkidle" });
+  await page.getByRole("heading", { name: "OctaCard" }).waitFor({ state: "visible" });
+  await page.evaluate(() => {
+    const button = Array.from(document.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("Select Directory"),
+    );
+    if (!button) throw new Error("Select Directory button not found after reload");
+    button.click();
+  });
+
+  const reloadedAlphaNode = page.getByTestId(alphaNodeTestId);
+  await reloadedAlphaNode.waitFor({ state: "visible" });
+  await page.waitForTimeout(1200);
+  const reloadedExpanded = await reloadedAlphaNode.getAttribute("data-expanded");
+  const persistedAfterReload = await page.evaluate(() => localStorage.getItem("octacard_nav_state_source__default"));
+  assert.equal(
+    reloadedExpanded,
+    "true",
+    `Expected reloaded folder to remain expanded. Persisted nav state: ${persistedAfterReload ?? "null"}`,
+  );
+
+  const reloadedChild = page.getByTestId(alphaChildTestId);
+  await reloadedChild.waitFor({ state: "visible" });
+  const childVisible = await reloadedChild.isVisible();
+  assert.ok(childVisible, "Expected expanded folder state to persist after reload.");
+}


### PR DESCRIPTION
Automated fix for issue #34: We should remember the state of the folders on relaunch. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed