### PR TITLE
fix: Automated fix for #40: Sample Waveform Display is too wide for sample files with long filenames

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -10,6 +10,7 @@ import { assertConvertDialogEllipsis } from "../../tests/convert-dialog-ellipsis
 import { assertExpandedFoldersPersistOnReload } from "../../tests/persist-expanded-folders.mjs";
 import { assertSampleRateOptions } from "../../tests/sample-rate-options.mjs";
 import { assertDevModeButton } from "../../tests/dev-mode-button.mjs";
+import { assertAudioPreviewFilenameTruncation } from "../../tests/audio-preview-filename-truncation.mjs";
 
 const baseUrl = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 const headless = process.env.PW_HEADLESS !== "false";
@@ -254,6 +255,7 @@ try {
 
   const sourceAlphaNode = page.getByTestId("tree-node-source-_Alpha");
   await sourceAlphaNode.waitFor({ state: "visible" });
+  await assertAudioPreviewFilenameTruncation(page);
   await assertExpandedFoldersPersistOnReload(page);
   await sourceAlphaNode.waitFor({ state: "visible" });
   await page.getByTestId("favorite-open-source-_Alpha").waitFor({ state: "visible" });

--- a/src/components/AudioPreview.tsx
+++ b/src/components/AudioPreview.tsx
@@ -641,11 +641,16 @@ export const AudioPreview = ({ filePath, fileName, onClose, paneType = "source" 
     <div className="border-t border-border bg-card p-4 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          <span className="text-sm font-semibold uppercase tracking-wide text-muted-foreground truncate">
+          <span
+            data-testid="audio-preview-filename"
+            title={fileName}
+            className="block max-w-full text-sm font-semibold uppercase tracking-wide text-muted-foreground truncate"
+          >
             Preview: {fileName}
           </span>
         </div>
         <Button
+          data-testid="audio-preview-close"
           size="sm"
           variant="ghost"
           className="h-6 w-6 p-0"

--- a/src/components/FilePane.tsx
+++ b/src/components/FilePane.tsx
@@ -2646,7 +2646,7 @@ export const FilePane = ({
                     <File className="w-4 h-4 text-muted-foreground shrink-0" />
                   </>
                 )}
-                <span className={`text-sm truncate flex-1 ${isParentLink ? "text-muted-foreground italic" : ""}`}>
+                <span className={`text-sm truncate flex-1 min-w-0 ${isParentLink ? "text-muted-foreground italic" : ""}`}>
                   {node.name}
                 </span>
                 {node.size && <span className="text-xs text-muted-foreground font-mono">{node.size}</span>}

--- a/tests/audio-preview-filename-truncation.mjs
+++ b/tests/audio-preview-filename-truncation.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+const longFolderNodeTestId = "tree-node-source-_LongNames";
+const longFileNodeTestId =
+  "tree-node-source-_LongNames_this-is-an-extremely-long-sample-name-designed-to-overflow-the-dialog-display_wav";
+
+export async function assertAudioPreviewFilenameTruncation(page) {
+  const sourcePanel = page.getByTestId("panel-source");
+  await sourcePanel.waitFor({ state: "visible" });
+
+  await page.getByTestId(longFolderNodeTestId).click();
+  const longFileNode = page.getByTestId(longFileNodeTestId);
+  await longFileNode.waitFor({ state: "visible" });
+  await longFileNode.click();
+
+  const previewFileName = page.getByTestId("audio-preview-filename");
+  await previewFileName.waitFor({ state: "visible" });
+
+  const overflowMetrics = await sourcePanel.evaluate((panel) => ({
+    clientWidth: panel.clientWidth,
+    scrollWidth: panel.scrollWidth,
+  }));
+  assert.ok(
+    overflowMetrics.scrollWidth <= overflowMetrics.clientWidth + 1,
+    `Expected source panel to avoid horizontal overflow. scrollWidth=${overflowMetrics.scrollWidth}, clientWidth=${overflowMetrics.clientWidth}`,
+  );
+
+  const fileNameMetrics = await previewFileName.evaluate((element) => ({
+    display: window.getComputedStyle(element).display,
+    overflow: window.getComputedStyle(element).overflow,
+    textOverflow: window.getComputedStyle(element).textOverflow,
+    whiteSpace: window.getComputedStyle(element).whiteSpace,
+  }));
+  assert.ok(
+    fileNameMetrics.display === "block" &&
+      fileNameMetrics.overflow === "hidden" &&
+      fileNameMetrics.textOverflow === "ellipsis" &&
+      fileNameMetrics.whiteSpace === "nowrap",
+    `Expected preview filename to use block ellipsis truncation. display=${fileNameMetrics.display}, overflow=${fileNameMetrics.overflow}, textOverflow=${fileNameMetrics.textOverflow}, whiteSpace=${fileNameMetrics.whiteSpace}`,
+  );
+
+  await page.getByTestId("audio-preview-close").click();
+}


### PR DESCRIPTION
Automated fix for issue #40: Sample Waveform Display is too wide for sample files with long filenames. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed