### PR TITLE
fix: Automated fix for #47: Reveal in Finder opens a 'select folder' dialog instead of finder

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -6,6 +6,7 @@ import { assertDestRefreshAfterConvert } from "../../tests/refresh-dest.mjs";
 import { assertRevealInFinder } from "../../tests/reveal-in-finder.mjs";
 import { assertRevealInFinderDest } from "../../tests/reveal-in-finder-dest.mjs";
 import { assertRevealFileInFinder } from "../../tests/reveal-file-in-finder.mjs";
+import { assertRevealInFinderDoesNotOpenPickerFallback } from "../../tests/reveal-in-finder-no-picker-fallback.mjs";
 import { assertConvertDialogEllipsis } from "../../tests/convert-dialog-ellipsis.mjs";
 import { assertExpandedFoldersPersistOnReload } from "../../tests/persist-expanded-folders.mjs";
 import { assertSampleRateOptions } from "../../tests/sample-rate-options.mjs";
@@ -272,6 +273,7 @@ try {
     window.__revealCalls = [];
   });
   await assertRevealFileInFinder(page);
+  await assertRevealInFinderDoesNotOpenPickerFallback(page);
   await page.evaluate(() => {
     const sourceFavorite = document.querySelector('[data-testid="favorite-open-source-_Alpha"]');
     const destFavorite = document.querySelector('[data-testid="favorite-open-dest-_Beta"]');

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -392,32 +392,10 @@ class FileSystemService {
       }
       return { success: true };
     }
-
-    if (!("showDirectoryPicker" in window) && typeof (window as any).__octacardPickDirectory !== "function") {
-      return {
-        success: false,
-        error: "File System Access API not supported in this browser",
-      };
-    }
-
-    try {
-      const registry = this.getRegistry(paneType);
-      const targetPath = isDirectory ? virtualPath : this.getParentPath(virtualPath);
-      const cachedHandle = registry.getCachedDirectoryHandle(targetPath) ?? registry.getRoot();
-      await this.pickDirectoryHandle(paneType, cachedHandle ?? undefined);
-      return { success: true };
-    } catch (error: any) {
-      if (error?.name === "AbortError") {
-        return {
-          success: false,
-          error: "User cancelled directory selection",
-        };
-      }
-      return {
-        success: false,
-        error: String(error),
-      };
-    }
+    return {
+      success: false,
+      error: "Reveal in Finder is not supported in this environment",
+    };
   }
 
   getRootDirectoryName(paneType?: PaneType): string {

--- a/tests/reveal-in-finder-no-picker-fallback.mjs
+++ b/tests/reveal-in-finder-no-picker-fallback.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+
+export async function assertRevealInFinderDoesNotOpenPickerFallback(page) {
+  const pickerCallsBeforeReveal = await page.evaluate(() => {
+    if (window.__octacardTestHooks) {
+      delete window.__octacardTestHooks.revealInFinder;
+    }
+    delete window.__octacardRevealInFinder;
+    window.__revealCalls = [];
+    return Array.isArray(window.__pickerCalls) ? window.__pickerCalls.length : 0;
+  });
+
+  const alphaNode = page.getByTestId("tree-node-source-_Alpha");
+  await alphaNode.waitFor({ state: "visible" });
+  await alphaNode.click({ button: "right" });
+
+  const revealMenuItem = page.getByRole("menuitem", { name: "Reveal in Finder" });
+  await revealMenuItem.waitFor({ state: "visible" });
+  await revealMenuItem.click();
+
+  await page.waitForTimeout(250);
+
+  const { pickerCallsAfterReveal, revealCallsAfterReveal } = await page.evaluate(() => ({
+    pickerCallsAfterReveal: Array.isArray(window.__pickerCalls) ? window.__pickerCalls.length : 0,
+    revealCallsAfterReveal: Array.isArray(window.__revealCalls) ? window.__revealCalls.length : 0,
+  }));
+
+  assert.equal(
+    pickerCallsAfterReveal,
+    pickerCallsBeforeReveal,
+    "Reveal in Finder should not open a directory picker fallback.",
+  );
+  assert.equal(revealCallsAfterReveal, 0, "Reveal hook should not be called when reveal bridge is unavailable.");
+}


### PR DESCRIPTION
Automated fix for issue #47: Reveal in Finder opens a 'select folder' dialog instead of finder. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed