### PR TITLE
fix: Automated fix for #46: Cancel file copies or conversions is slow

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -15,6 +15,7 @@ import { assertHeaderDoesNotShowSelectDirectory } from "../../tests/header-selec
 import { assertWaveformPreviewDockedAtBottom } from "../../tests/waveform-preview-position.mjs";
 import { assertAudioPreviewFilenameTruncation } from "../../tests/audio-preview-filename-truncation.mjs";
 import { assertTermsAndPrivacyLinks } from "../../tests/tos-privacy-links.mjs";
+import { assertConversionCanBeCancelled } from "../../tests/conversion-cancel.mjs";
 
 const baseUrl = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 const headless = process.env.PW_HEADLESS !== "false";
@@ -114,6 +115,7 @@ try {
     const alpha = root.addDirectory(new MockDirectoryHandle("Alpha"));
     const beta = root.addDirectory(new MockDirectoryHandle("Beta"));
     const longNames = root.addDirectory(new MockDirectoryHandle("LongNames"));
+    const bulk = root.addDirectory(new MockDirectoryHandle("Bulk"));
     alpha.addFile("inside-alpha.wav", 128);
     beta.addFile("inside-beta.wav", 128);
     root.addFile("top-level.txt", 32);
@@ -121,6 +123,9 @@ try {
       "this-is-an-extremely-long-sample-name-designed-to-overflow-the-dialog-display.wav",
       128,
     );
+    for (let i = 1; i <= 6; i++) {
+      bulk.addFile(`bulk-${i}.wav`, 128);
+    }
 
     const ensureDirectoryByPath = (virtualPath) => {
       const parts = virtualPath.split("/").filter(Boolean);
@@ -183,10 +188,30 @@ try {
             ],
           };
         }
+        if (startPath === "/Bulk") {
+          return {
+            success: true,
+            data: Array.from({ length: 6 }, (_, i) => ({
+              name: `bulk-${i + 1}.wav`,
+              path: `/Bulk/bulk-${i + 1}.wav`,
+              type: "file",
+              size: 128,
+              isDirectory: false,
+            })),
+          };
+        }
         return { success: true, data: [] };
       },
       convertAndCopyFile: async (args) => {
         window.__convertCalls.push(args);
+        if (args.sourceVirtualPath?.startsWith("/Bulk/")) {
+          for (let i = 0; i < 20; i++) {
+            if (args.signal?.aborted) {
+              return { success: false, error: "Operation cancelled", cancelled: true };
+            }
+            await new Promise((resolve) => setTimeout(resolve, 25));
+          }
+        }
         addFileToPath(args.destVirtualPath, args.fileName);
         if (args.fileName.length > 40) {
           await new Promise((resolve) => setTimeout(resolve, 300));
@@ -387,8 +412,10 @@ try {
   await destBetaNode.click();
 
   await assertConvertDialogEllipsis(page);
+  await assertConversionCanBeCancelled(page);
 
   await page.getByTestId("tree-node-source-_Alpha").click();
+  await destBetaNode.click();
 
   await formatButton.click();
   await page.getByRole("menuitem", { name: "Sample Rate" }).hover();

--- a/src/lib/audioConverter.ts
+++ b/src/lib/audioConverter.ts
@@ -6,6 +6,19 @@ let ffmpegInstance: FFmpeg | null = null;
 let isInitialized = false;
 let isInitializing = false;
 
+export function cancelActiveConversion(): void {
+  if (ffmpegInstance) {
+    try {
+      ffmpegInstance.terminate();
+    } catch {
+      // Ignore terminate errors during cancellation.
+    }
+  }
+  ffmpegInstance = null;
+  isInitialized = false;
+  isInitializing = false;
+}
+
 interface ConversionOptions {
   sampleRate?: number;
   bitDepth?: '16-bit' | 'dont-change';

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -16,6 +16,7 @@ export interface FileSystemResult<T = any> {
   success: boolean;
   data?: T;
   error?: string;
+  cancelled?: boolean;
 }
 
 export interface PaneDirectorySelection {
@@ -42,6 +43,7 @@ interface OctacardTestHooks {
     trimStart?: boolean;
     sourcePane: PaneType;
     destPane: PaneType;
+    signal?: AbortSignal;
   }) => Promise<FileSystemResult> | FileSystemResult;
   revealInFinder?: (args: {
     virtualPath: string;
@@ -717,7 +719,16 @@ class FileSystemService {
     trimStart?: boolean,
     sourcePane: PaneType = "source",
     destPane: PaneType = "dest",
+    signal?: AbortSignal,
   ): Promise<FileSystemResult> {
+    if (signal?.aborted) {
+      return {
+        success: false,
+        error: "Operation cancelled",
+        cancelled: true,
+      };
+    }
+
     const testConvert = this.getTestHooks()?.convertAndCopyFile;
     if (typeof testConvert === "function") {
       return await testConvert({
@@ -733,10 +744,33 @@ class FileSystemService {
         trimStart,
         sourcePane,
         destPane,
+        signal,
       });
     }
 
+    let abortListener: (() => void) | null = null;
     try {
+      if (signal) {
+        abortListener = () => {
+          import("./audioConverter")
+            .then(({ cancelActiveConversion }) => {
+              cancelActiveConversion();
+            })
+            .catch(() => {
+              // Ignore cancellation cleanup errors
+            });
+        };
+        signal.addEventListener("abort", abortListener, { once: true });
+      }
+
+      if (signal?.aborted) {
+        return {
+          success: false,
+          error: "Operation cancelled",
+          cancelled: true,
+        };
+      }
+
       // Get source file
       const sourceFile = await this.getFile(sourceVirtualPath, sourcePane);
       if (!sourceFile) {
@@ -794,6 +828,14 @@ class FileSystemService {
         finalFile = convertedBlob;
       }
 
+      if (signal?.aborted) {
+        return {
+          success: false,
+          error: "Operation cancelled",
+          cancelled: true,
+        };
+      }
+
       // Write to destination (ensure nested dirs exist)
       const destDirHandle = await this.getRegistry(destPane).ensureDirectory(destVirtualPath);
 
@@ -815,12 +857,31 @@ class FileSystemService {
 
       await writable.close();
 
+      if (signal?.aborted) {
+        return {
+          success: false,
+          error: "Operation cancelled",
+          cancelled: true,
+        };
+      }
+
       return { success: true };
     } catch (error) {
+      if (signal?.aborted) {
+        return {
+          success: false,
+          error: "Operation cancelled",
+          cancelled: true,
+        };
+      }
       return {
         success: false,
         error: String(error),
       };
+    } finally {
+      if (signal && abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
     }
   }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { FilePane } from "@/components/FilePane";
 import { FavoritesColumn } from "@/components/FavoritesColumn";
 import { FormatDropdown, type FormatSettings } from "@/components/FormatDropdown";
@@ -10,6 +10,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -84,6 +85,9 @@ const Index = () => {
     sourceBasePath: string;
     destinationBasePath: string;
   } | null>(null);
+  const [cancelConversionPromptOpen, setCancelConversionPromptOpen] = useState(false);
+  const conversionCancelRequestedRef = useRef(false);
+  const conversionAbortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (isSafari()) {
@@ -206,6 +210,8 @@ const Index = () => {
     const request = pendingConversionRequest;
     if (!request || request.files.length === 0) return;
     const { files, sourceBasePath, destinationBasePath } = request;
+    conversionCancelRequestedRef.current = false;
+    conversionAbortControllerRef.current = new AbortController();
 
     const targetSampleRate =
       formatSettings.sampleRate === "dont-change"
@@ -221,85 +227,106 @@ const Index = () => {
 
     const errors: Array<{ name: string; error: string }> = [];
     try {
-    for (let i = 0; i < files.length; i++) {
-      const entry = files[i];
-      setConversionProgress((p) =>
-        p ? { ...p, current: i, currentFile: entry.name } : p
-      );
-
-      const sourcePrefix = sourceBasePath === "/" ? "/" : `${sourceBasePath}/`;
-      const relativePath = entry.path.startsWith(sourcePrefix)
-        ? entry.path.slice(sourcePrefix.length)
-        : entry.name;
-      const dirParts = relativePath.split("/");
-      const fileName = dirParts.pop() || entry.name;
-      const destDir = dirParts.length ? `${destinationBasePath}/${dirParts.join("/")}` : destinationBasePath;
-
-      const result = await fileSystemService.convertAndCopyFile(
-        entry.path,
-        destDir,
-        fileName,
-        targetSampleRate,
-        formatSettings.sampleDepth === "dont-change" ? undefined : formatSettings.sampleDepth,
-        formatSettings.fileFormat === "dont-change" ? undefined : formatSettings.fileFormat,
-        formatSettings.pitch === "dont-change" ? undefined : formatSettings.pitch,
-        formatSettings.mono,
-        formatSettings.normalize,
-        formatSettings.trim,
-        "source",
-        "dest"
-      );
-      if (!result.success) {
-        errors.push({ name: entry.name, error: result.error || "Conversion failed" });
-      }
-    }
-
-    setConversionProgress((p) =>
-      p ? { ...p, current: files.length, currentFile: "" } : p
-    );
-    setDestRefreshToken((v) => v + 1);
-    setPendingConversionRequest(null);
-    setTimeout(() => setConversionProgress(null), 500);
-
-    if (errors.length > 0) {
-      const failedCount = errors.length;
-      const totalCount = files.length;
-      toast.error(
-        failedCount === totalCount ? "Conversion Failed" : "Some Files Failed",
-        {
-          description:
-            failedCount === totalCount
-              ? errors[0]?.error ?? "Unable to convert files."
-              : `${failedCount} of ${totalCount} files failed: ${errors.map((e) => e.name).join(", ")}`,
-          duration: 6000,
+      for (let i = 0; i < files.length; i++) {
+        if (conversionCancelRequestedRef.current) {
+          break;
         }
+        const entry = files[i];
+        setConversionProgress((p) =>
+          p ? { ...p, current: i, currentFile: entry.name } : p
+        );
+
+        const sourcePrefix = sourceBasePath === "/" ? "/" : `${sourceBasePath}/`;
+        const relativePath = entry.path.startsWith(sourcePrefix)
+          ? entry.path.slice(sourcePrefix.length)
+          : entry.name;
+        const dirParts = relativePath.split("/");
+        const fileName = dirParts.pop() || entry.name;
+        const destDir = dirParts.length ? `${destinationBasePath}/${dirParts.join("/")}` : destinationBasePath;
+
+        const result = await fileSystemService.convertAndCopyFile(
+          entry.path,
+          destDir,
+          fileName,
+          targetSampleRate,
+          formatSettings.sampleDepth === "dont-change" ? undefined : formatSettings.sampleDepth,
+          formatSettings.fileFormat === "dont-change" ? undefined : formatSettings.fileFormat,
+          formatSettings.pitch === "dont-change" ? undefined : formatSettings.pitch,
+          formatSettings.mono,
+          formatSettings.normalize,
+          formatSettings.trim,
+          "source",
+          "dest",
+          conversionAbortControllerRef.current.signal,
+        );
+        if (!result.success) {
+          if (result.cancelled || conversionCancelRequestedRef.current) {
+            break;
+          }
+          errors.push({ name: entry.name, error: result.error || "Conversion failed" });
+        }
+      }
+
+      if (conversionCancelRequestedRef.current) {
+        setConversionProgress(null);
+        setPendingConversionRequest(null);
+        toast("Conversion Cancelled", {
+          description: "Stopped converting files.",
+        });
+        return;
+      }
+
+      setConversionProgress((p) =>
+        p ? { ...p, current: files.length, currentFile: "" } : p
       );
-    }
+      setDestRefreshToken((v) => v + 1);
+      setPendingConversionRequest(null);
+      setTimeout(() => setConversionProgress(null), 500);
 
-    const hasConversion =
-      formatSettings.sampleRate !== "dont-change" ||
-      formatSettings.sampleDepth !== "dont-change" ||
-      formatSettings.fileFormat !== "dont-change" ||
-      formatSettings.pitch !== "dont-change" ||
-      formatSettings.mono ||
-      formatSettings.normalize ||
-      formatSettings.trim;
+      if (errors.length > 0) {
+        const failedCount = errors.length;
+        const totalCount = files.length;
+        toast.error(
+          failedCount === totalCount ? "Conversion Failed" : "Some Files Failed",
+          {
+            description:
+              failedCount === totalCount
+                ? errors[0]?.error ?? "Unable to convert files."
+                : `${failedCount} of ${totalCount} files failed: ${errors.map((e) => e.name).join(", ")}`,
+            duration: 6000,
+          }
+        );
+      }
 
-    capture("octacard_conversion_completed", {
-      file_count: files.length,
-      error_count: errors.length,
-      has_conversion: hasConversion,
-      settings: {
-        sampleRate: formatSettings.sampleRate,
-        sampleDepth: formatSettings.sampleDepth,
-        fileFormat: formatSettings.fileFormat,
-        pitch: formatSettings.pitch,
-        mono: formatSettings.mono,
-        normalize: formatSettings.normalize,
-        trimStart: formatSettings.trim,
-      },
-    });
+      const hasConversion =
+        formatSettings.sampleRate !== "dont-change" ||
+        formatSettings.sampleDepth !== "dont-change" ||
+        formatSettings.fileFormat !== "dont-change" ||
+        formatSettings.pitch !== "dont-change" ||
+        formatSettings.mono ||
+        formatSettings.normalize ||
+        formatSettings.trim;
+
+      capture("octacard_conversion_completed", {
+        file_count: files.length,
+        error_count: errors.length,
+        has_conversion: hasConversion,
+        settings: {
+          sampleRate: formatSettings.sampleRate,
+          sampleDepth: formatSettings.sampleDepth,
+          fileFormat: formatSettings.fileFormat,
+          pitch: formatSettings.pitch,
+          mono: formatSettings.mono,
+          normalize: formatSettings.normalize,
+          trimStart: formatSettings.trim,
+        },
+      });
     } catch (err) {
+      if (conversionCancelRequestedRef.current) {
+        setConversionProgress(null);
+        setPendingConversionRequest(null);
+        return;
+      }
       setConversionProgress(null);
       setPendingConversionRequest(null);
       toast.error("Conversion Failed", {
@@ -328,6 +355,9 @@ const Index = () => {
         },
         error: err instanceof Error ? err.message : String(err),
       });
+    } finally {
+      conversionAbortControllerRef.current = null;
+      setCancelConversionPromptOpen(false);
     }
   };
 
@@ -587,7 +617,14 @@ const Index = () => {
       )}
 
       {conversionProgress?.isVisible && (
-        <Dialog open={true} onOpenChange={() => {}}>
+        <Dialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setCancelConversionPromptOpen(true);
+            }
+          }}
+        >
           <DialogContent className="sm:max-w-md">
             <DialogHeader className="min-w-0">
               <DialogTitle>Converting Files</DialogTitle>
@@ -620,6 +657,34 @@ const Index = () => {
           </DialogContent>
         </Dialog>
       )}
+
+      <Dialog open={cancelConversionPromptOpen} onOpenChange={setCancelConversionPromptOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Cancel conversion?</DialogTitle>
+            <DialogDescription>
+              Conversion is currently running. You can keep converting or cancel now.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCancelConversionPromptOpen(false)}>
+              Keep Converting
+            </Button>
+            <Button
+              onClick={() => {
+                conversionCancelRequestedRef.current = true;
+                setCancelConversionPromptOpen(false);
+                conversionAbortControllerRef.current?.abort();
+                setConversionProgress((p) =>
+                  p ? { ...p, currentFile: "Cancelling conversion..." } : p
+                );
+              }}
+            >
+              Cancel Conversion
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/tests/conversion-cancel.mjs
+++ b/tests/conversion-cancel.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+
+export async function assertConversionCanBeCancelled(page) {
+  await page.evaluate(() => {
+    window.__listCalls = [];
+    window.__convertCalls = [];
+  });
+
+  await page.getByTestId("tree-node-source-_Bulk").click();
+  await page.getByTestId("tree-node-dest-_Beta").click();
+  await page.getByRole("button", { name: "Convert" }).click();
+
+  const confirmButtons = ["Convert & Save", "Copy"];
+  let confirmClicked = false;
+  for (const name of confirmButtons) {
+    const button = page.getByRole("button", { name });
+    if (await button.isVisible().catch(() => false)) {
+      await button.click();
+      confirmClicked = true;
+      break;
+    }
+  }
+  assert.ok(confirmClicked, "Expected to confirm conversion before testing cancellation.");
+
+  const progressDialog = page.getByRole("dialog").filter({ hasText: "Converting Files" });
+  await progressDialog.waitFor({ state: "visible" });
+  await page.waitForFunction(() => Array.isArray(window.__convertCalls) && window.__convertCalls.length >= 1);
+
+  await progressDialog.getByRole("button", { name: "Close" }).click();
+  const cancelPrompt = page.getByRole("dialog").filter({ hasText: "Cancel conversion?" });
+  await cancelPrompt.waitFor({ state: "visible" });
+  await cancelPrompt.getByRole("button", { name: "Cancel Conversion" }).click();
+
+  await progressDialog.waitFor({ state: "hidden" });
+  await page.waitForTimeout(250);
+
+  const convertCalls = await page.evaluate(() => window.__convertCalls);
+  assert.ok(convertCalls.length < 6, `Expected cancellation before all files were processed. Calls=${convertCalls.length}`);
+
+  await page.evaluate(() => {
+    window.__listCalls = [];
+    window.__convertCalls = [];
+  });
+}


### PR DESCRIPTION
Automated fix for issue #46: Cancel file copies or conversions is slow. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed