### PR TITLE
fix: Automated fix for #62: Can't cancel lengthy operations

### DIFF
--- a/scripts/integration/smoke.mjs
+++ b/scripts/integration/smoke.mjs
@@ -17,6 +17,7 @@ import { assertWaveformPreviewDockedAtBottom } from "../../tests/waveform-previe
 import { assertAudioPreviewFilenameTruncation } from "../../tests/audio-preview-filename-truncation.mjs";
 import { assertTermsAndPrivacyLinks } from "../../tests/tos-privacy-links.mjs";
 import { assertConversionCanBeCancelled } from "../../tests/conversion-cancel.mjs";
+import { assertLargeBatchConversionCanBeCancelledQuickly } from "../../tests/conversion-cancel-large-batch.mjs";
 import { assertDragDropConvertsWithFormat } from "../../tests/drag-drop-conversion.mjs";
 import { assertDragFolderDropConvertsWithoutConfirmation } from "../../tests/drag-folder-drop-convert.mjs";
 import { assertIndexedSearchUsesCache, assertSearchFindsConvertedFileAfterReindex } from "../../tests/search-indexing.mjs";
@@ -122,6 +123,7 @@ try {
     const guitars = alpha.addDirectory(new MockDirectoryHandle("Guitars"));
     const longNames = root.addDirectory(new MockDirectoryHandle("LongNames"));
     const bulk = root.addDirectory(new MockDirectoryHandle("Bulk"));
+    const huge = root.addDirectory(new MockDirectoryHandle("Huge"));
     alpha.addFile("inside-alpha.wav", 128);
     guitars.addFile("clean_gtr_center.wav", 128);
     beta.addFile("inside-beta.wav", 128);
@@ -132,6 +134,9 @@ try {
     );
     for (let i = 1; i <= 6; i++) {
       bulk.addFile(`bulk-${i}.wav`, 128);
+    }
+    for (let i = 1; i <= 300; i++) {
+      huge.addFile(`huge-${i}.wav`, 64);
     }
 
     const ensureDirectoryByPath = (virtualPath) => {
@@ -204,6 +209,18 @@ try {
               path: `/Bulk/bulk-${i + 1}.wav`,
               type: "file",
               size: 128,
+              isDirectory: false,
+            })),
+          };
+        }
+        if (startPath === "/Huge") {
+          return {
+            success: true,
+            data: Array.from({ length: 300 }, (_, i) => ({
+              name: `huge-${i + 1}.wav`,
+              path: `/Huge/huge-${i + 1}.wav`,
+              type: "file",
+              size: 64,
               isDirectory: false,
             })),
           };
@@ -518,6 +535,7 @@ try {
   );
 
   await assertDragDropConvertsWithFormat(page);
+  await assertLargeBatchConversionCanBeCancelledQuickly(page);
 
   assert.equal(domNestingWarnings.length, 0, "No DOM nesting warnings should be emitted during conversion flow.");
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -51,6 +51,12 @@ function isSafari(): boolean {
   return ua.includes("safari") && !ua.includes("chrome") && !ua.includes("chromium");
 }
 
+async function yieldToUi(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 const Index = () => {
   const [aboutOpen, setAboutOpen] = useState(false);
   const devMode = useAppOptionsStore((s) => s.devMode);
@@ -237,6 +243,10 @@ const Index = () => {
     const errors: Array<{ name: string; error: string }> = [];
     try {
       for (let i = 0; i < files.length; i++) {
+        if (conversionCancelRequestedRef.current) {
+          break;
+        }
+        await yieldToUi();
         if (conversionCancelRequestedRef.current) {
           break;
         }

--- a/tests/conversion-cancel-large-batch.mjs
+++ b/tests/conversion-cancel-large-batch.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+
+export async function assertLargeBatchConversionCanBeCancelledQuickly(page) {
+  const formatButton = page.getByRole("button", { name: "Format" });
+  await formatButton.click();
+  await page.getByRole("menuitem", { name: "Sample Depth" }).hover();
+  await page.getByRole("menuitemradio", { name: "Don't change" }).click();
+  await page.waitForSelector('[role="menu"]', { state: "hidden", timeout: 2000 }).catch(() => {});
+
+  await page.evaluate(() => {
+    window.__listCalls = [];
+    window.__convertCalls = [];
+  });
+
+  await page.getByTestId("tree-node-source-_Huge").click();
+  await page.getByTestId("tree-node-dest-_Beta").click();
+  await page.getByRole("button", { name: "Convert" }).click();
+
+  const copyButton = page.getByRole("button", { name: "Copy" });
+  await copyButton.waitFor({ state: "visible" });
+  await copyButton.click();
+
+  const progressDialog = page.getByRole("dialog").filter({ hasText: "Converting Files" });
+  await progressDialog.waitFor({ state: "visible" });
+  await page.waitForFunction(() => Array.isArray(window.__convertCalls) && window.__convertCalls.length >= 1);
+
+  await progressDialog.getByRole("button", { name: "Close" }).click();
+  const cancelPrompt = page.getByRole("dialog").filter({ hasText: "Cancel conversion?" });
+  await cancelPrompt.waitFor({ state: "visible" });
+  await cancelPrompt.getByRole("button", { name: "Cancel Conversion" }).click();
+
+  await progressDialog.waitFor({ state: "hidden", timeout: 5000 });
+  await page.waitForTimeout(100);
+
+  const convertCalls = await page.evaluate(() => window.__convertCalls.length);
+  assert.ok(convertCalls < 80, `Expected quick cancellation in large batch. Calls=${convertCalls}`);
+
+  await page.evaluate(() => {
+    window.__listCalls = [];
+    window.__convertCalls = [];
+  });
+}

--- a/tests/drag-folder-drop-convert.mjs
+++ b/tests/drag-folder-drop-convert.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 
 export async function assertDragFolderDropConvertsWithoutConfirmation(page) {
+  const formatButton = page.getByRole("button", { name: "Format" });
+  await formatButton.click();
+  await page.getByRole("menuitem", { name: "Sample Depth" }).hover();
+  await page.getByRole("menuitemradio", { name: "16-bit" }).click();
+  await page.waitForSelector('[role="menu"]', { state: "hidden", timeout: 2000 }).catch(() => {});
+
   const sourceAlphaNode = page.getByTestId("tree-node-source-_Alpha");
   const destBetaNode = page.getByTestId("tree-node-dest-_Beta");
   await sourceAlphaNode.waitFor({ state: "visible" });


### PR DESCRIPTION
Automated fix for issue #62: Can't cancel lengthy operations. This PR was created by the AI-Fixer skill, adds an integration test, and implements the fix. Tests: passed